### PR TITLE
Fixes and feature requests August 18th

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -120,13 +120,14 @@ const plugin = {
       });
 
       // Ensure that dashboardNote exists in a state where await this._noteContent(dashboardNote) can be called on it
-      let dashboardNote = await app.findNote({ name: dashboardNoteTitle, tag: this.constants.defaultBaseTag });
+      const baseTag = app.settings[this.constants.settingTagName] || this.constants.defaultBaseTag;
+      let dashboardNote = await app.findNote({ name: dashboardNoteTitle, tag: baseTag});
       if (dashboardNote) {
         console.log("Found existing dashboard note", dashboardNote, "for", dashboardNoteTitle);
         dashboardNote = await app.notes.find(dashboardNote.uuid);
       } else {
         console.log("Creating dashboard note anew");
-        dashboardNote = await app.notes.create(dashboardNoteTitle, [ this.constants.defaultBaseTag ]);
+        dashboardNote = await app.notes.create(dashboardNoteTitle, [ baseTag ]);
       }
       
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -28,7 +28,7 @@ const plugin = {
     readwiseHighlightsIndexURL: "https://readwise.io/api/v2/highlights",
     readwisePageSize: 1000, // Highlights and Books both claim they can support page sizes up to 1000 so we'll take them up on that to reduce number of requests we need to make
     sectionRegex: /^#+\s*([^#\n\r]+)/gm,
-    settingAuthorTag: "Save authors as tags (\"true\" or \"false\". Default: true)",
+    settingAuthorTag: "Save authors as tags (\"true\" or \"false\". Default: false)",
     settingDateFormat: "Date format (default: en-US)",
     settingDiscardedName: "Import discarded highlights (\"true\" or \"false\". Default: false)",
     settingSortOrderName: "Highlight sort order (\"newest\" or \"oldest\". Default: newest)",
@@ -606,7 +606,7 @@ const plugin = {
 
       // Create the note if it doesn't exist
       const bookNoteTags = [`${ baseTag }/${ this._textToTagName(readwiseBook.category) }`];
-      if (app.settings[this.constants.settingAuthorTag] !== "false") {
+      if (app.settings[this.constants.settingAuthorTag] === "true") {
         const candidateAuthorTag = this._textToTagName(readwiseBook.author);
         const authorTag = candidateAuthorTag && candidateAuthorTag.split("-").slice(0, 3).join("-");
         // Avoid inserting uber-long multi-author tag names that would pollute the tag space


### PR DESCRIPTION
Two changes:

1. Don't save tags for authors by default
2. Don't omit adding a custom tag to the dashboard library if the user chose one

For large libraries and especially those that have lots of non-traditional-book content (eg. tweets), saving authors creates a lot of unnecessary tags, so it should be better to keep this option off by default.