### PR TITLE
Fix: don't throw when encountering rows with lower number of columns

### DIFF
--- a/dist/out.plugin.js
+++ b/dist/out.plugin.js
@@ -194,11 +194,14 @@
       const cells = row.split(/(?<!\\)\|/).slice(1, -1).map((cell) => cell.trim());
       const rowObj = {};
       headers.forEach((header, i) => {
-        if (!cells[i]) {
+        if (cells[i] === "") {
           console.error(`Couldn't find a book property in the table.
 Analyzing row: ${row}`);
           throw new Error(`Couldn't find a book property in the table.
 Analyzing row: ${row}`);
+        }
+        if (cells[i] === void 0) {
+          cells.push(`[No ${header}]`);
         }
         rowObj[header] = cells[i] || null;
       });
@@ -1111,6 +1114,7 @@ Working concurrently while notes are being changed could lead to merge issues, s
         }
       } catch (error) {
         if (this._testEnvironment) {
+          console.log(error);
           throw error;
         } else {
           console.trace();

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -160,9 +160,19 @@ export function _tableFromMarkdown(content) {
 
     const rowObj = {};
     headers.forEach((header, i) => {
-      if (!cells[i]) {
+      if (cells[i] === "") {
+        // Most likely to happen if we are reading a table with empty columns
+        // We don't want to catch cells[i] == undefined, since that is an actual error state
         console.error(`Couldn't find a book property in the table.\nAnalyzing row: ${row}`);
         throw new Error(`Couldn't find a book property in the table.\nAnalyzing row: ${row}`);
+      }
+      if (cells[i] === undefined) {
+        // Most likely to happen if the number of columns we are reading is smaller than the one assumed by the code
+        // We want to insert "[No <header name>]" in those columns
+        // TODO: should properly treat missing columns, perhaps refetch that info from Readwise?
+        // Note: as of writing this code, it's not clearly determined what happens to existing books in the dashboard
+        // Do we refetch them? (Probably yes, and) If so, the issue will fix itself and this cell will be re-filled
+        cells.push(`[No ${header}]`);
       }
       rowObj[header] = cells[i] || null;
     });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -266,6 +266,7 @@ const plugin = {
       }
     } catch (error) {
       if (this._testEnvironment) {
+        console.log(error);
         throw(error);
       } else {
         console.trace();

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -239,6 +239,30 @@ describe("plugin1", () => {
         expect(app._noteRegistry["2"].body).toContain(expectedBookNoteContent);
       });
     });
+    describe("with a populated dashboard that has fewer columns than expected", () => {
+      beforeEach(() => {
+        // Note: this is faulty because we have 8 columns in the first two rows and just 7 in the last row
+        // Not sure how we can reach this state, but it's been logged on some users' installations
+        let faultyDashboardContent = `Readwise books imported into table: 1
+- Book count reported by Readwise: 1
+# Readwise Book List
+## 2012
+| **Cover** | **Book Title** | **Author** | **Category** | **Source** | **Highlights** | **Updated** | **Other Details** |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| ![\\|200](https://images-na.ssl-images-amazon.com/images/I/51y7BxD2f5L._SL200_.jpg) | [It's All Too Much](https://www.amplenote.com/notes/2) | Peter Walsh | books | [kindle](kindle://book?action=open&asin=B000N2HCP6) | [1 highlight](https://www.amplenote.com/notes/2#Highlights}) | March 29, 2012 |
+`;
+        dashboardNote = mockNote(faultyDashboardContent, plugin.constants.dashboardConstants.defaultDashboardNoteTitle,
+            dashboardNoteUUID, ["library"])
+        app = mockApp(dashboardNote);
+        plugin._app = app;
+      });
+
+      // ------------------------------------------------------------------------------------------
+      it("should add mising content to the missing columns", async () => {
+        await expect(plugin._syncAll(app)).resolves.not.toThrow();
+        validateDashboard(app, dashboardNote, expectedDashboardRegex, expectedDashboardContent);
+      })
+    });
 
     describe("with a faulty dashboard: empty row", () => {
       let dashboardNote, app;


### PR DESCRIPTION
As reported by two users last month, we should now be treating a case (that I don't yet know how to reproduce, but I'm assuming it's generated by running newer code on older dashboards ) where some rows have fewer columns than the Header row of the Book List table.