### PR TITLE
Fix plugin not working on ample-desktop & mobile

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -80,9 +80,10 @@ export function _markdownFromTableRow(headers, item) {
     row = headers.map(header => {
       let cellContents = "";
       // First make sure there are no pipe "|" characters in the cell (except for when specifying the size of an image)
-      cellContents = item[header].replace(/(?<!!\[.*\\)\|/g, ",") || ""; // TODO: should not enter empty strings in the table
+      cellContents = item[header].replace(/(?<!!\[.*\\)\|/g, ",");
       // Then remove all new line characters from the cell
       cellContents = cellContents.replace(/\n/gm, " ");
+      if (cellContents === "") cellContents = `[No ${header}]`;
       return cellContents;
     });
   } catch (err) {

--- a/lib/readwise.js
+++ b/lib/readwise.js
@@ -166,18 +166,23 @@ export async function _readwiseMakeRequest(app, constants, url) {
     throw new Error('Readwise API key is empty. Please provide a valid API key.');
   }
 
-  const headers = new Headers({ "Authorization": `Token ${ readwiseAPIKey }`, "Content-Type": 'application/json' });
+  const headers = new Headers({ "Authorization": `Token ${ readwiseAPIKey }`, "Content-Type": 'application/json' , "Origin": "https://plugins.amplenote.com", "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"});
 
   // Wait to ensure we don't exceed the requests/minute quota of Readwise
   await _ensureRequestDelta(app, constants);
 
-  // Use a proxy until Readwise adds CORS preflight headers
-  const proxyUrl = `https://amplenote-plugins-cors-anywhere.onrender.com/${ url.toString() }`;
+  let proxyUrl;
+  // Requests to cors proxies will fail from electron & mobile; attempt once and remove proxy if we get 400
+  proxyUrl = `https://plugins.amplenote.com/cors-proxy/${ url.toString() }`;
   const tryFetch = async () => {
     const response = await fetch(proxyUrl, { method: 'GET', headers });
-
     if (!response.ok) {
       console.error(`HTTP error. Status: ${ response.status }`);
+      if (response.status == 400) { // We might be trying a fetch to a CORS from outside a browser (mobile/electron)
+        proxyUrl = url.toString();
+        const response = await fetch(proxyUrl, { method: 'GET', headers });
+        if (response.ok) return response.json();
+      }
       return null;
     } else {
       return response.json();


### PR DESCRIPTION
Try a `fetch` and retry it without the CORS proxy if we get a 400 error (happens when making calls to a cors-anywhere proxy from outside a browser).

Also added a small change that should ensure we don't insert empty strings inside dashboard tables, which can produce errors down the line. This one will be completed with further fixes to address a user-reported issue.