### PR TITLE
Fixed "no highlight date" typo.

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -355,7 +355,7 @@ const plugin = {
     // const sortOrder = app.settings[constants.bookConstants.settingSortOrderName] || constants.bookConstants.defaultHighlightSort;
     let hlGroups = _groupByValue(bookNoteHighlightList,
         item => {
-          if (!item.highlighted_at) return "No higlight date";
+          if (!item.highlighted_at) return "No highlight date";
           let year = _yearFromDateString(item.highlighted_at);
           if (!year) return "No highlight date";
           return year;


### PR DESCRIPTION
If there is no highlight date, there's a misspelling, saying "No higlight date". 